### PR TITLE
CloseConnection doesn't return error

### DIFF
--- a/branch/starter/main.go
+++ b/branch/starter/main.go
@@ -20,7 +20,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		TaskList: "branch",

--- a/branch/worker/main.go
+++ b/branch/worker/main.go
@@ -19,16 +19,15 @@ func main() {
 
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
+		Logger:   logger,
 		HostPort: client.DefaultHostPort,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "branch", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "branch", worker.Options{})
 
 	w.RegisterWorkflow(branch.SampleBranchWorkflow)
 	w.RegisterActivity(branch.SampleActivity)

--- a/cancelactivity/cancel/main.go
+++ b/cancelactivity/cancel/main.go
@@ -30,7 +30,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	err = c.CancelWorkflow(context.Background(), workflowID, "")
 	if err != nil {

--- a/cancelactivity/starter/main.go
+++ b/cancelactivity/starter/main.go
@@ -27,7 +27,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       workflowID,

--- a/cancelactivity/worker/main.go
+++ b/cancelactivity/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "cancel-activity", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "cancel-activity", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(cancelactivity.Workflow)

--- a/child-workflow-continue-as-new/starter/main.go
+++ b/child-workflow-continue-as-new/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	// This workflow ID can be user business logic identifier as well.
 	workflowID := "parent-workflow_" + uuid.New()

--- a/child-workflow-continue-as-new/worker/main.go
+++ b/child-workflow-continue-as-new/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "child-workflow-continue-as-new", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "child-workflow-continue-as-new", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(cw.SampleParentWorkflow)

--- a/child-workflow/starter/main.go
+++ b/child-workflow/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	// This workflow ID can be user business logic identifier as well.
 	workflowID := "parent-workflow_" + uuid.New()

--- a/child-workflow/worker/main.go
+++ b/child-workflow/worker/main.go
@@ -8,7 +8,7 @@ import (
 	"go.temporal.io/temporal/worker"
 	"go.uber.org/zap"
 
-	"github.com/temporalio/temporal-go-samples/child-workflow"
+	child_workflow "github.com/temporalio/temporal-go-samples/child-workflow"
 )
 
 func main() {
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "child-workflow", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "child-workflow", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(child_workflow.SampleParentWorkflow)

--- a/choice-exclusive/starter/main.go
+++ b/choice-exclusive/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "exclusive_" + uuid.New(),

--- a/choice-exclusive/worker/main.go
+++ b/choice-exclusive/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "choice", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "choice", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(choice.ExclusiveChoiceWorkflow)

--- a/choice-multi/starter/main.go
+++ b/choice-multi/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "multi_choice_" + uuid.New(),

--- a/choice-multi/worker/main.go
+++ b/choice-multi/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "choice-multi", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "choice-multi", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(choice_multi.MultiChoiceWorkflow)

--- a/cron/starter/main.go
+++ b/cron/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	// This workflow ID can be user business logic identifier as well.
 	workflowID := "cron_" + uuid.New()

--- a/cron/worker/main.go
+++ b/cron/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "cron", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "cron", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(cron.SampleCronWorkflow)

--- a/ctxpropagation/starter/main.go
+++ b/ctxpropagation/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowID := "ctx-propagation_" + uuid.New()
 	workflowOptions := client.StartWorkflowOptions{

--- a/ctxpropagation/worker/main.go
+++ b/ctxpropagation/worker/main.go
@@ -24,14 +24,14 @@ func main() {
 		ContextPropagators: []workflow.ContextPropagator{
 			ctxpropagation.NewContextPropagator(),
 		},
+		Logger: logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	w := worker.New(c, "ctx-propagation", worker.Options{
-		Logger:                logger,
 		EnableLoggingInReplay: true,
 	})
 	defer w.Stop()

--- a/dsl/worker/main.go
+++ b/dsl/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "dsl", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "dsl", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(dsl.SimpleDSLWorkflow)

--- a/dynamic/starter/main.go
+++ b/dynamic/starter/main.go
@@ -21,7 +21,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	// This workflow ID can be user business logic identifier as well.
 	workflowID := "dynamic_" + uuid.New()

--- a/dynamic/worker/main.go
+++ b/dynamic/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "dynamic", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "dynamic", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(dynamic.SampleGreetingsWorkflow)

--- a/expense/starter/main.go
+++ b/expense/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	expenseID := uuid.New()
 	workflowOptions := client.StartWorkflowOptions{

--- a/expense/worker/main.go
+++ b/expense/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "expense", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "expense", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(expense.SampleExpenseWorkflow)

--- a/fileprocessing/starter/main.go
+++ b/fileprocessing/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	fileID := uuid.New()
 	workflowOptions := client.StartWorkflowOptions{

--- a/fileprocessing/worker/main.go
+++ b/fileprocessing/worker/main.go
@@ -20,14 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workerOptions := worker.Options{
-		Logger:              logger,
 		EnableSessionWorker: true, // Important for a worker to participate in the session
 	}
 	w := worker.New(c, "fileprocessing", workerOptions)

--- a/go.mod
+++ b/go.mod
@@ -5,21 +5,22 @@ go 1.13
 require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/mock v1.4.3
+	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/pborman/uuid v1.2.0
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/uber-go/tally v3.3.16+incompatible // indirect
 	github.com/uber/jaeger-client-go v2.23.1+incompatible // indirect
-	go.temporal.io/temporal v0.22.8
+	go.temporal.io/temporal v0.22.9
 	go.temporal.io/temporal-proto v0.20.34
 	go.uber.org/zap v1.15.0
 	golang.org/x/mod v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20200513185701-a91f0712d120 // indirect
-	golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c // indirect
+	golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
-	golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97 // indirect
-	google.golang.org/genproto v0.0.0-20200514193133-8feb7f20f2a2 // indirect
+	golang.org/x/tools v0.0.0-20200515193602-8ddc06776ea3 // indirect
+	google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587 // indirect
 	google.golang.org/grpc v1.29.1 // indirect
-	google.golang.org/protobuf v1.23.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
+	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/uber-go/tally v3.3.16+incompatible // indirect
 	github.com/uber/jaeger-client-go v2.23.1+incompatible // indirect
-	go.temporal.io/temporal v0.22.9
+	go.temporal.io/temporal v0.23.0
 	go.temporal.io/temporal-proto v0.20.34
 	go.uber.org/zap v1.15.0
 	golang.org/x/mod v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/uber/jaeger-client-go v2.23.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.temporal.io/temporal v0.22.9 h1:gtkrOUtKJgRBTYZkCKj/53EXzuXb21yOSzji+W7gpak=
-go.temporal.io/temporal v0.22.9/go.mod h1:fCMDQ1ZBowNFc92Hny7nRXigLFJzXgD2zvAFQO4WMpI=
+go.temporal.io/temporal v0.23.0 h1:jp6nqRZPxfrHLeMKlxbs0ZD/ueJGioV2KAUDWYXsWRM=
+go.temporal.io/temporal v0.23.0/go.mod h1:fCMDQ1ZBowNFc92Hny7nRXigLFJzXgD2zvAFQO4WMpI=
 go.temporal.io/temporal-proto v0.20.34 h1:IHv0Tpai7n0ayqTo6PZTASIFjdh9XvP+fOTcSmL/yw4=
 go.temporal.io/temporal-proto v0.20.34/go.mod h1:Lv8L8YBpbp0Z7V5nbvw5UD0j7x0isebhCOIDLkBqn6s=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
+github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -112,8 +114,8 @@ github.com/uber/jaeger-client-go v2.23.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMW
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.temporal.io/temporal v0.22.8 h1:9C56YlU+zoDzumd2BQvgJT/LQyAJ2HGF7yBg80zQr10=
-go.temporal.io/temporal v0.22.8/go.mod h1:fCMDQ1ZBowNFc92Hny7nRXigLFJzXgD2zvAFQO4WMpI=
+go.temporal.io/temporal v0.22.9 h1:gtkrOUtKJgRBTYZkCKj/53EXzuXb21yOSzji+W7gpak=
+go.temporal.io/temporal v0.22.9/go.mod h1:fCMDQ1ZBowNFc92Hny7nRXigLFJzXgD2zvAFQO4WMpI=
 go.temporal.io/temporal-proto v0.20.34 h1:IHv0Tpai7n0ayqTo6PZTASIFjdh9XvP+fOTcSmL/yw4=
 go.temporal.io/temporal-proto v0.20.34/go.mod h1:Lv8L8YBpbp0Z7V5nbvw5UD0j7x0isebhCOIDLkBqn6s=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
@@ -174,8 +176,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20u
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775 h1:TC0v2RSO1u2kn1ZugjrFXkRZAEaqMN/RW+OTZkBzmLE=
 golang.org/x/sys v0.0.0-20200327173247-9dae0f8f5775/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c h1:kISX68E8gSkNYAFRFiDU8rl5RIn1sJYKYb/r2vMLDrU=
-golang.org/x/sys v0.0.0-20200513112337-417ce2331b5c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9 h1:YTzHMGlqJu67/uEo1lBv0n3wBXhXNeUbB1XfN2vmTm0=
+golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -201,8 +203,8 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e h1:qCZ8SbsZMjT0OuDPCEBxgLZic4NMj8Gj4vNXiTVRAaA=
 golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
-golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97 h1:DAuln/hGp+aJiHpID1Y1hYzMEPP5WLwtZHPb50mN0OE=
-golang.org/x/tools v0.0.0-20200513201620-d5fe73897c97/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200515193602-8ddc06776ea3 h1:3wUEFIQPGG80rjhMrLsfa7M8KcNO2DdkfqlmnkIF2mI=
+golang.org/x/tools v0.0.0-20200515193602-8ddc06776ea3/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -217,8 +219,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200325114520-5b2d0af7952b/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200326112834-f447254575fd h1:DVCc2PgW9UrvHGZGEv4Mt3uSeQtUrrs7r8pUw+bVwWI=
 google.golang.org/genproto v0.0.0-20200326112834-f447254575fd/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200514193133-8feb7f20f2a2 h1:RwW6+LxyOQJ7oeoZ76GIJlwt/O0J5cN2fk+q/jK27kQ=
-google.golang.org/genproto v0.0.0-20200514193133-8feb7f20f2a2/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
+google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587 h1:1Ym+vvUpq1ZHvxzn34gENJX8U4aKO+vhy2P/2+Xl6qQ=
+google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
@@ -257,5 +259,7 @@ honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXe
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
+honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/greetings/starter/main.go
+++ b/greetings/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "greetings_" + uuid.New(),

--- a/greetings/worker/main.go
+++ b/greetings/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "greetings", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "greetings", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(greetings.GreetingSample)

--- a/helloworld/starter/main.go
+++ b/helloworld/starter/main.go
@@ -20,7 +20,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "hello_world_workflowID",

--- a/helloworld/worker/main.go
+++ b/helloworld/worker/main.go
@@ -18,15 +18,15 @@ func main() {
 	}
 
 	// The client and worker are heavyweight objects that should be created once per process.
-	c, err := client.NewClient(client.Options{})
+	c, err := client.NewClient(client.Options{
+		Logger: logger,
+	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "hello-world", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "hello-world", worker.Options{})
 	defer w.Stop()
 
 	w.RegisterWorkflow(helloworld.Workflow)

--- a/mutex/starter/main.go
+++ b/mutex/starter/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	// This workflow ID can be user business logic identifier as well.
 	resourceID := uuid.New()
@@ -49,7 +50,4 @@ func main() {
 	} else {
 		logger.Info("Started workflow2", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
 	}
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/mutex/worker/main.go
+++ b/mutex/worker/main.go
@@ -21,13 +21,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	w := worker.New(c, "mutex", worker.Options{
-		Logger:                    logger,
 		BackgroundActivityContext: context.WithValue(context.Background(), mutex.ClientContextKey, c),
 	})
 
@@ -39,12 +40,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to start worker", zap.Error(err))
 	}
+	defer w.Stop()
 
 	// The workers are supposed to be long running process that should not exit.
 	waitCtrlC()
-	// Stop worker, close connection, clean up resources.
-	w.Stop()
-	_ = c.CloseConnection()
 }
 
 func waitCtrlC() {

--- a/parallel/starter/main.go
+++ b/parallel/starter/main.go
@@ -23,7 +23,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 	workflowOptions := client.StartWorkflowOptions{
 		TaskList: "parallel",
 	}

--- a/parallel/worker/main.go
+++ b/parallel/worker/main.go
@@ -20,15 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
-	defer func() { _ = c.CloseConnection() }()
+	defer c.CloseConnection()
 
-	w := worker.New(c, "parallel", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "parallel", worker.Options{})
 
 	w.RegisterWorkflow(parallel.SampleParallelWorkflow)
 	w.RegisterActivity(parallel.SampleActivity)

--- a/pickfirst/starter/main.go
+++ b/pickfirst/starter/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "pick-first_" + uuid.New(),
@@ -34,7 +35,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/pickfirst/worker/main.go
+++ b/pickfirst/worker/main.go
@@ -20,14 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
-	w := worker.New(c, "pick-first", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "pick-first", worker.Options{})
 
 	w.RegisterWorkflow(pickfirst.SamplePickFirstWorkflow)
 	w.RegisterActivity(pickfirst.SampleActivity)
@@ -36,12 +36,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to start worker", zap.Error(err))
 	}
+	defer w.Stop()
 
 	// The workers are supposed to be long running process that should not exit.
 	waitCtrlC()
-	// Stop worker, close connection, clean up resources.
-	w.Stop()
-	_ = c.CloseConnection()
 }
 
 func waitCtrlC() {

--- a/pso/query/main.go
+++ b/pso/query/main.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	resp, err := c.QueryWorkflow(context.Background(), workflowID, runID, queryType)
 	if err != nil {
@@ -40,7 +41,4 @@ func main() {
 		logger.Error("Unable to decode query result", zap.Error(err))
 	}
 	logger.Info("Received query result", zap.Any("Result", result))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/pso/starter/main.go
+++ b/pso/starter/main.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "PSO_" + uuid.New(),
@@ -40,7 +41,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/query/query/main.go
+++ b/query/query/main.go
@@ -26,6 +26,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	resp, err := c.QueryWorkflow(context.Background(), workflowID, "", queryType)
 	if err != nil {
@@ -36,7 +37,4 @@ func main() {
 		logger.Error("Unable to decode query result", zap.Error(err))
 	}
 	logger.Info("Received query result", zap.Any("Result", result))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/query/starter/main.go
+++ b/query/starter/main.go
@@ -22,6 +22,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "query_workflow",
@@ -33,7 +34,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/query/worker/main.go
+++ b/query/worker/main.go
@@ -20,14 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
-	w := worker.New(c, "query", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "query", worker.Options{})
 
 	w.RegisterWorkflow(query.QueryWorkflow)
 
@@ -35,12 +35,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to start worker", zap.Error(err))
 	}
+	defer w.Stop()
 
 	// The workers are supposed to be long running process that should not exit.
 	waitCtrlC()
-	// Stop worker, close connection, clean up resources.
-	w.Stop()
-	_ = c.CloseConnection()
 }
 
 func waitCtrlC() {

--- a/recovery/query/main.go
+++ b/recovery/query/main.go
@@ -27,6 +27,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	resp, err := c.QueryWorkflow(context.Background(), workflowID, "", recovery.QueryName)
 	if err != nil {
@@ -37,7 +38,4 @@ func main() {
 		logger.Error("Unable to decode query result", zap.Error(err))
 	}
 	logger.Info("Received query result", zap.Any("Result", result))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/recovery/signal/main.go
+++ b/recovery/signal/main.go
@@ -29,6 +29,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	var tripEvent recovery.TripEvent
 	if err := json.Unmarshal([]byte(signal), &tripEvent); err != nil {
@@ -39,7 +40,4 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to signal workflow", zap.Error(err))
 	}
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/recovery/starter/main.go
+++ b/recovery/starter/main.go
@@ -30,6 +30,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	var we client.WorkflowRun
 	var weError error
@@ -57,7 +58,6 @@ func main() {
 		we, weError = c.ExecuteWorkflow(context.Background(), workflowOptions, recovery.RecoverWorkflow, params)
 	default:
 		flag.PrintDefaults()
-		_ = c.CloseConnection()
 		return
 	}
 
@@ -66,7 +66,4 @@ func main() {
 	} else {
 		logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
 	}
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/recovery/worker/main.go
+++ b/recovery/worker/main.go
@@ -23,16 +23,17 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	ctx := context.WithValue(context.Background(), recovery.TemporalClientKey, c)
 	ctx = context.WithValue(ctx, recovery.WorkflowExecutionCacheKey, cache.NewLRU(10))
 
 	w := worker.New(c, "recovery", worker.Options{
-		Logger:                    logger,
 		BackgroundActivityContext: ctx,
 	})
 
@@ -45,12 +46,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to start worker", zap.Error(err))
 	}
+	defer w.Stop()
 
 	// The workers are supposed to be long running process that should not exit.
 	waitCtrlC()
-	// Stop worker, close connection, clean up resources.
-	w.Stop()
-	_ = c.CloseConnection()
 }
 
 func waitCtrlC() {

--- a/retryactivity/starter/main.go
+++ b/retryactivity/starter/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "retry_activity_" + uuid.New(),
@@ -34,7 +35,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/searchattributes/starter/main.go
+++ b/searchattributes/starter/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "search_attributes_" + uuid.New(),
@@ -37,7 +38,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/splitmerge/starter/main.go
+++ b/splitmerge/starter/main.go
@@ -23,6 +23,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "split_merge_" + uuid.New(),
@@ -34,7 +35,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/splitmerge/worker/main.go
+++ b/splitmerge/worker/main.go
@@ -20,14 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
-	w := worker.New(c, "split-merge", worker.Options{
-		Logger: logger,
-	})
+	w := worker.New(c, "split-merge", worker.Options{})
 
 	w.RegisterWorkflow(splitmerge.SampleSplitMergeWorkflow)
 	w.RegisterActivity(splitmerge.ChunkProcessingActivity)
@@ -36,12 +36,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to start worker", zap.Error(err))
 	}
+	defer w.Stop()
 
 	// The workers are supposed to be long running process that should not exit.
 	waitCtrlC()
-	// Stop worker, close connection, clean up resources.
-	w.Stop()
-	_ = c.CloseConnection()
 }
 
 func waitCtrlC() {

--- a/timer/starter/main.go
+++ b/timer/starter/main.go
@@ -24,6 +24,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	workflowOptions := client.StartWorkflowOptions{
 		ID:       "timer_" + uuid.New(),
@@ -35,7 +36,4 @@ func main() {
 		logger.Fatal("Unable to execute workflow", zap.Error(err))
 	}
 	logger.Info("Started workflow", zap.String("WorkflowID", we.GetID()), zap.String("RunID", we.GetRunID()))
-
-	// Close connection, clean up resources.
-	_ = c.CloseConnection()
 }

--- a/timer/worker/main.go
+++ b/timer/worker/main.go
@@ -20,13 +20,14 @@ func main() {
 	// The client and worker are heavyweight objects that should be created once per process.
 	c, err := client.NewClient(client.Options{
 		HostPort: client.DefaultHostPort,
+		Logger:   logger,
 	})
 	if err != nil {
 		logger.Fatal("Unable to create client", zap.Error(err))
 	}
+	defer c.CloseConnection()
 
 	w := worker.New(c, "timer", worker.Options{
-		Logger:                             logger,
 		MaxConcurrentActivityExecutionSize: 3,
 	})
 
@@ -38,12 +39,10 @@ func main() {
 	if err != nil {
 		logger.Fatal("Unable to start worker", zap.Error(err))
 	}
+	defer w.Stop()
 
 	// The workers are supposed to be long running process that should not exit.
 	waitCtrlC()
-	// Stop worker, close connection, clean up resources.
-	w.Stop()
-	_ = c.CloseConnection()
 }
 
 func waitCtrlC() {


### PR DESCRIPTION
Update GoSDK to the latest version. `CloseConnection` doesn't return error anymore and can be defered directly.